### PR TITLE
Add AICalcX and annotate PrivyDoc with MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ dotnet add package Microsoft.Agents.AI
 ### Community Examples
 
 - [PrivyDoc](https://github.com/ShivamGoyal03/PrivyDoc) (Microsoft MVP) - Local document intelligence tool powered by Foundry Local for secure, on-device document analysis
-- [AICalcX](https://github.com/ShivamGoyal03/AICalcX) (Microsoft MVP) - Real-time, transparent AI project cost estimation that combines live Azure pricing, human resource inputs, and autonomous agents, adapts to pricing, usage, and model parameters to produce accurate enterprise TCO. Experimental or WIP, see [BLOCKERS.md](https://github.com/ShivamGoyal03/AICalcX/blob/main/BLOCKERS.md)
+- [AICalcX](https://github.com/ShivamGoyal03/AICalcX) (Microsoft MVP) - Real-time AI project cost estimation combining live Azure pricing, human resources, and autonomous agents for accurate enterprise TCO. (Experimental – see [BLOCKERS.md](https://github.com/ShivamGoyal03/AICalcX/blob/main/BLOCKERS.md))
 
 ## 🛠️ Tools & Frameworks
 


### PR DESCRIPTION
Hi @webmaxru ,

This PR adds AICalcX to Community Examples and tags both AICalcX and PrivyDoc with "Microsoft MVP" as we discussed.

What is included
- AICalcX: Real-time, transparent AI project cost estimation that combines live Azure pricing, human resource inputs, and autonomous agents. It adapts to pricing, usage, and model parameters to produce accurate enterprise TCO. Current status is experimental or WIP. Open items are in BLOCKERS.md.
- PrivyDoc: Updated the existing entry to include the "Microsoft MVP" tag.

Links
- AICalcX: https://github.com/ShivamGoyal03/AICalcX
- BLOCKERS.md: https://github.com/ShivamGoyal03/AICalcX/blob/main/BLOCKERS.md
- PrivyDoc: https://github.com/ShivamGoyal03/PrivyDoc

Thanks for the quick green light.